### PR TITLE
Map traces to original TypeScript lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "repro-nest",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "repro-nest",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "repro-nest",
-  "version": "0.0.17",
+  "version": "0.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "repro-nest",
-      "version": "0.0.17",
+      "version": "0.0.19",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.4",
@@ -17,11 +17,8 @@
         "@babel/types": "^7.28.4",
         "@jridgewell/trace-mapping": "^0.3.25",
         "express": "^5.1.0",
-        "import-in-the-middle": "^1.14.4",
         "mongoose": "^8.18.2",
-        "pirates": "^4.0.7",
-        "require-in-the-middle": "^8.0.0",
-        "shimmer": "^1.2.1"
+        "pirates": "^4.0.7"
       },
       "devDependencies": {
         "@types/express": "^5.0.3"
@@ -578,27 +575,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "acorn": "^8"
-      }
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.8.tgz",
@@ -727,12 +703,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/cjs-module-lexer": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
-      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -1099,18 +1069,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/import-in-the-middle": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.4.tgz",
-      "integrity": "sha512-eWjxh735SJLFJJDs5X82JQ2405OdJeAHDBnaoFCfdr5GVc7AWc9xU7KbrF+3Xd5F2ccP1aQFKtY+65X6EfKZ7A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "acorn": "^8.14.0",
-        "acorn-import-attributes": "^1.9.5",
-        "cjs-module-lexer": "^1.2.2",
-        "module-details-from-path": "^1.0.3"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1236,12 +1194,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/module-details-from-path": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
-      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
-      "license": "MIT"
     },
     "node_modules/mongodb": {
       "version": "6.18.0",
@@ -1490,19 +1442,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/require-in-the-middle": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.0.tgz",
-      "integrity": "sha512-9s0pnM5tH8G4dSI3pms2GboYOs25LwOGnRMxN/Hx3TYT1K0rh6OjaWf4dI0DAQnMyaEXWoGVnSTPQasqwzTTAA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.5",
-        "module-details-from-path": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
-      }
-    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -1596,12 +1535,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
-    },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/side-channel": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,11 @@
         "@babel/types": "^7.28.4",
         "@jridgewell/trace-mapping": "^0.3.25",
         "express": "^5.1.0",
+        "import-in-the-middle": "^1.14.4",
         "mongoose": "^8.18.2",
-        "pirates": "^4.0.7"
+        "pirates": "^4.0.7",
+        "require-in-the-middle": "^8.0.0",
+        "shimmer": "^1.2.1"
       },
       "devDependencies": {
         "@types/express": "^5.0.3"
@@ -575,6 +578,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.8.tgz",
@@ -703,6 +727,12 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -1069,6 +1099,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.4.tgz",
+      "integrity": "sha512-eWjxh735SJLFJJDs5X82JQ2405OdJeAHDBnaoFCfdr5GVc7AWc9xU7KbrF+3Xd5F2ccP1aQFKtY+65X6EfKZ7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1194,6 +1236,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
     },
     "node_modules/mongodb": {
       "version": "6.18.0",
@@ -1442,6 +1490,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.0.tgz",
+      "integrity": "sha512-9s0pnM5tH8G4dSI3pms2GboYOs25LwOGnRMxN/Hx3TYT1K0rh6OjaWf4dI0DAQnMyaEXWoGVnSTPQasqwzTTAA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -1535,6 +1596,12 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/side-channel": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@babel/plugin-transform-typescript": "^7.28.0",
         "@babel/traverse": "^7.28.4",
         "@babel/types": "^7.28.4",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "express": "^5.1.0",
         "import-in-the-middle": "^1.14.4",
         "mongoose": "^8.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repro-nest",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Repro Nest SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
     "@babel/traverse": "^7.28.4",
     "@babel/types": "^7.28.4",
     "express": "^5.1.0",
+    "mongoose": "^8.18.2",
+    "@jridgewell/trace-mapping": "^0.3.25",
     "import-in-the-middle": "^1.14.4",
-    "mongoose": ">=6",
     "pirates": "^4.0.7",
     "require-in-the-middle": "^8.0.0",
     "shimmer": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repro-nest",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Repro Nest SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repro-nest",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Repro Nest SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,22 +99,16 @@ let __TRACER_READY = false;
 //         // include ONLY app code (no node_modules) to avoid interfering with deps
 //         const include = [ new RegExp('^' + escapeRx(cwd) + '/(?!node_modules/)') ];
 //
-//         // additionally exclude common model/schema folders to be extra safe
-//         const extraExcludes = [
-//             '/model/', '/models/', '/schema/', '/schemas/', '/db/', '/database/', '/mongo/', '/repositories?/'
-//         ].map(seg => new RegExp(escapeRx(cwd) + '.*' + seg));
-//
 //         // exclude this SDK itself (and any babel internals if present)
 //         const exclude = [
 //             new RegExp('^' + escapeRx(sdkRoot) + '/'),
 //             /node_modules[\\/]@babel[\\/].*/,
-//             ...extraExcludes,
 //         ];
 //
 //         tracerPkg.init?.({
 //             instrument: true,               // tracer can instrument app code
 //             include,
-//             exclude,                        // but never our SDK or common data/model paths
+//             exclude,                        // but never our SDK
 //             mode: process.env.TRACE_MODE || 'v8',
 //             samplingMs: 10,
 //         });
@@ -149,10 +143,7 @@ function defaultTracerInitOpts(): TracerInitOpts {
     const escapeRx = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
     const include = [ new RegExp('^' + escapeRx(cwd) + '/(?!node_modules/)') ];
-    const extraExcludes = [
-        '/model/', '/models/', '/schema/', '/schemas/', '/db/', '/database/', '/mongo/', '/repositories?/'
-    ].map(seg => new RegExp(escapeRx(cwd) + '.*' + seg));
-
+    // Only skip our own files and Babel internals; repository/service layers stay instrumented.
     const exclude = [
         new RegExp('^' + escapeRx(sdkRoot) + '/'), // never instrument the SDK itself
         /node_modules[\\/]@babel[\\/].*/,


### PR DESCRIPTION
## Summary
- read TypeScript source maps during CommonJS compilation to recover the original source filename and line mappings
- pass the recovered mapping into the Babel wrap plugin so function and call-site metadata report the true TypeScript locations
- add @jridgewell/trace-mapping as a runtime dependency to decode source maps

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4229b205c832788dee996e3420021