### PR TITLE
Add trace file suppression and improve mongoose query result payloads

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -86,9 +86,12 @@ Provides a shorthand for muting every trace event whose source file matches the
 supplied patterns. Strings are case-insensitive and match either the filename
 suffix (when no slash is present) or any path segment (when the string contains
 `/`). For very short tokens (one or two characters), provide the full filename
-or basename you want to ignore (for example `"db"` to skip `db.ts`). Regular
-expressions receive the normalized path with forward slashes, so the same
-pattern works on all platforms.
+or basename you want to ignore (for example `"db"` to skip `db.ts`). When you
+filter by directory, single-segment folder names shorter than four characters
+(such as `"src/"` or `"db/"`) are ignored to prevent muting every trace; use a
+more specific path like `"src/services/"` or switch to a regular expression in
+those cases. Regular expressions receive the normalized path with forward
+slashes, so the same pattern works on all platforms.
 
 ```ts
 import { setDisabledTraceFiles } from '@repro/sdk';

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -85,8 +85,10 @@ to remove previously configured rules.
 Provides a shorthand for muting every trace event whose source file matches the
 supplied patterns. Strings are case-insensitive and match either the filename
 suffix (when no slash is present) or any path segment (when the string contains
-`/`). Regular expressions receive the normalized path with forward slashes, so
-the same pattern works on all platforms.
+`/`). For very short tokens (one or two characters), provide the full filename
+or basename you want to ignore (for example `"db"` to skip `db.ts`). Regular
+expressions receive the normalized path with forward slashes, so the same
+pattern works on all platforms.
 
 ```ts
 import { setDisabledTraceFiles } from '@repro/sdk';

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -19,6 +19,12 @@ initReproTracing({
     (event) => event.fn?.startsWith('debug') ?? false,
   ],
   disableFunctionTypes: ['constructor'],
+  // Silence every trace event emitted from specific source files
+  disableTraceFiles: [
+    'src/services/debug.service.ts',   // filename suffix match
+    'src/utils/',                      // directory match (must include a slash)
+    /node_modules\/some-logger\//i,    // or a RegExp against the normalized path
+  ],
   logFunctionCalls: false,
 });
 ```
@@ -73,6 +79,27 @@ setDisabledFunctionTraces([
 
 Pass `null` or an empty array to `initReproTracing` or `setDisabledFunctionTraces`
 to remove previously configured rules.
+
+## `disableTraceFiles`
+
+Provides a shorthand for muting every trace event whose source file matches the
+supplied patterns. Strings are case-insensitive and match either the filename
+suffix (when no slash is present) or any path segment (when the string contains
+`/`). Regular expressions receive the normalized path with forward slashes, so
+the same pattern works on all platforms.
+
+```ts
+import { setDisabledTraceFiles } from '@repro/sdk';
+
+// stop recording traces from local development helpers
+setDisabledTraceFiles([
+  'src/dev-tools/',
+  'scripts/seed.ts',
+]);
+
+// reset the filter later on
+setDisabledTraceFiles(null);
+```
 
 ## `logFunctionCalls`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,6 +230,14 @@ function filePatternsMatch(file: string | null | undefined, patterns: Array<stri
 
         if (normalizedPattern.includes('/')) {
             if (!normalizedFile) return false;
+            const segments = normalizedPattern.split('/').filter(Boolean);
+            if (!segments.length) return false;
+
+            const effectiveLength = segments.reduce((len, segment) => len + segment.length, 0);
+            if (segments.length === 1 && effectiveLength < 4) {
+                return false;
+            }
+
             return normalizedFile.includes(normalizedPattern);
         }
 


### PR DESCRIPTION
## Summary
- add a `setDisabledTraceFiles` helper and `disableTraceFiles` init option to filter traces by source filename
- normalize mongoose values before serialization so query metadata returns plain data instead of raw documents
- include real query results in `resultMeta`, capturing documents/values counts and truncation info for find/aggregate/distinct operations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f90e6843788327a93a600b1e6e526e